### PR TITLE
Update Scparco.quark

### DIFF
--- a/Scparco.quark
+++ b/Scparco.quark
@@ -1,5 +1,5 @@
 (
-  name : "Scparco",
+  name: "Scparco",
   summary: "Quark to simplify parsing text",
   version: "0.0.4",
   schelp: "Scparco.schelp",


### PR DESCRIPTION
typo correction

On my end, the white space between name and : causes an error when compiling sclang. By removing the whitespace, I could fix the problem.